### PR TITLE
Fin de traductions dans tutorial.po

### DIFF
--- a/tutorial.po
+++ b/tutorial.po
@@ -4852,7 +4852,7 @@ msgstr ""
 
 #: ../src/Doc/tutorial/interactive.rst:5
 msgid "Interactive Input Editing and History Substitution"
-msgstr ""
+msgstr "Édition interactive des entrées et substitution d'historique"
 
 #: ../src/Doc/tutorial/interactive.rst:7
 msgid ""
@@ -4864,6 +4864,15 @@ msgid ""
 "easily explained.  The interactive editing and history described here are "
 "optionally available in the Unix and Cygwin versions of the interpreter."
 msgstr ""
+"Certaines versions de l'interpréteur Python prennent en charge l'édition de la "
+"ligne d'entrée courante et la substitution d'historique, similaires aux "
+"facilités que l'on trouve dans le shell Korn et dans le shell GNU Bash. "
+"C'est implémenté en utilisant la bibliothèque `GNU Readline`_, qui supporte "
+"l'édition en style Emacs et en style Vi. La bibliothèque a sa propre "
+"documentation qui ne va pas être dupliquée ici ; toutefois, les bases seront "
+"expliquées rapidement. L'éditeur interactif et la gestion d'historique décrits "
+"ici sont disponibles en option sous les versions Unix et Cygwin de "
+"l'interpréteur."
 
 #: ../src/Doc/tutorial/interactive.rst:15
 msgid ""
@@ -4872,10 +4881,15 @@ msgid ""
 "Python. The command line history recall which operates within DOS boxes on "
 "NT and some other DOS and Windows flavors  is yet another beast."
 msgstr ""
+"Ce chapitre *ne décrit pas* les possibilités d'édition du paquet PythonWin "
+"de Mark Hammond ou de l'environnement basé sur Tk, IDLE, distribué avec "
+"Python. Le rappel d'historique des lignes de commandes qui fonctionne dans "
+"des fenêtres DOS sous NT ou d'autres variétés de Windows est encore une "
+"autre histoire."
 
 #: ../src/Doc/tutorial/interactive.rst:24
 msgid "Line Editing"
-msgstr ""
+msgstr "Édition de ligne"
 
 #: ../src/Doc/tutorial/interactive.rst:26
 msgid ""
@@ -4890,10 +4904,21 @@ msgid ""
 "string. :kbd:`C-underscore` undoes the last change you made; it can be "
 "repeated for cumulative effect."
 msgstr ""
+"Si elle est supportée, l'édition de la ligne d'entrée est active lorsque "
+"l'interpréteur affiche une invite primaire ou secondaire. La ligne courante "
+"peut être éditée en utilisant les caractères de contrôles traditionnels "
+"d'Emacs. Les plus importants d'entre eux sont : :kbd:`C-A` (Contrôle-A) "
+"déplace le curseur au début de la ligne, :kbd:`C-E` à la fin, :kbd:`C-B` "
+"d'un caractère vers la gauche, :kbd:`C-F` d'un caractère vers la droite. La "
+"touche retour arrière efface le caractère à la gauche du curseur, "
+":kbd:`C-D` le caractère à sa droite. :kbd:`C-K` supprime le reste de la ligne "
+"à la droite du curseur, :kbd:`C-Y` rappelle la dernière chaîne supprimée. "
+":kbd:`C-tiret bas` annule la dernière modification ; cette commande peut "
+"être répétée pour cumuler ses effets."
 
 #: ../src/Doc/tutorial/interactive.rst:41
 msgid "History Substitution"
-msgstr ""
+msgstr "Substitution d'historique"
 
 #: ../src/Doc/tutorial/interactive.rst:43
 msgid ""
@@ -4906,10 +4931,19 @@ msgid ""
 "line to the interpreter.  :kbd:`C-R` starts an incremental reverse search; :"
 "kbd:`C-S` starts a forward search."
 msgstr ""
+"La substitution d'historique fonctionne comme ceci. Toutes les lignes non "
+"vides reçues sont enregistrées dans un tampon d'historique et, à chaque fois "
+"qu'une invite est affichée, vous êtes positionné sur une nouvelle ligne à la "
+"fin de ce tampon. :kbd:`C-P` remonte d'une ligne (en arrière) dans ce tampon, "
+":kbd:`C-N` descend d'une ligne. Chaque ligne présente dans le tampon "
+"d'historique peut être éditée ; un astérisque apparaît en face de l'invite "
+"pour indiquer qu'une ligne a été modifiée. Presser la touche :kbd:`Entrée` "
+"envoie la ligne en cours à l'interpréteur. :kbd:`C-R` démarre une recherche "
+"incrémentale en arrière ; :kbd:`C-S` démarre une recherche en avant."
 
 #: ../src/Doc/tutorial/interactive.rst:56
 msgid "Key Bindings"
-msgstr ""
+msgstr "Raccourcis clavier"
 
 #: ../src/Doc/tutorial/interactive.rst:58
 msgid ""
@@ -4917,18 +4951,21 @@ msgid ""
 "customized by placing commands in an initialization file called :file:`~/."
 "inputrc`.  Key bindings have the form ::"
 msgstr ""
+"Les raccourcis clavier ainsi que d'autres paramètres de la bibliothèque "
+"Readline peuvent être personnalisés en inscrivant des commandes dans un fichier "
+"d'initialisation appelé :file:`~/.inputrc`. Les raccourcis sont de la forme ::"
 
 #: ../src/Doc/tutorial/interactive.rst:64
 msgid "or ::"
-msgstr ""
+msgstr "ou ::"
 
 #: ../src/Doc/tutorial/interactive.rst:68
 msgid "and options can be set with ::"
-msgstr ""
+msgstr "et les options peuvent être définies avec ::"
 
 #: ../src/Doc/tutorial/interactive.rst:72
 msgid "For example::"
-msgstr ""
+msgstr "Par exemple ::"
 
 #: ../src/Doc/tutorial/interactive.rst:85
 msgid ""
@@ -4936,6 +4973,10 @@ msgid ""
 "`Tab` character instead of Readline's default filename completion function.  "
 "If you insist, you can override this by putting ::"
 msgstr ""
+"Notez que le raccourci par défaut pour la touche :kbd:`Tab` en Python est "
+"d'insérer un caractère de tabulation au lieu de la fonction par défaut de "
+"complétion des noms de fichiers de la bibliothèque Readline. Si vous y tenez, "
+"vous pouvez surcharger ce comportement en indiquant ::"
 
 #: ../src/Doc/tutorial/interactive.rst:91
 msgid ""
@@ -4943,6 +4984,9 @@ msgid ""
 "indented continuation lines if you're accustomed to using :kbd:`Tab` for "
 "that purpose.)"
 msgstr ""
+"dans votre fichier :file:`~/.inputrc` (bien sûr, avec cela il devient plus "
+"difficile d'entrer des lignes de continuation indentées si vous êtes habitué "
+"à utiliser :kbd:`Tab` dans ce but)."
 
 #: ../src/Doc/tutorial/interactive.rst:98
 msgid ""
@@ -4950,6 +4994,10 @@ msgid ""
 "To enable it in the interpreter's interactive mode, add the following to "
 "your startup file: [#]_  ::"
 msgstr ""
+"La complétude automatique des noms de variables et de modules est disponible "
+"de manière optionnelle. Pour l'activer dans le mode interactif de "
+"l'interpréteur, ajoutez les lignes suivantes à votre fichier de démarrage : "
+"[#]_ ::"
 
 #: ../src/Doc/tutorial/interactive.rst:105
 msgid ""
@@ -4961,6 +5009,15 @@ msgid ""
 "resulting object.  Note that this may execute application-defined code if an "
 "object with a :meth:`__getattr__` method is part of the expression."
 msgstr ""
+"Ceci lie la touche :kbd:`Tab` à la fonction de complétude, donc taper la "
+"touche :kbd:`Tab` deux fois de suite suggère les options disponibles ; la "
+"recherche s'effectue dans les noms d'instructions Python, les noms des "
+"variables locales et les noms de modules disponibles. Pour les expressions "
+"pointées telles que ``string.a``, l'expression est évaluée jusqu'au dernier "
+"``'.'`` avant de suggérer les options disponibles à partir des attributs "
+"de l'objet résultant de cette évaluation. Notez bien que ceci peut exécuter "
+"une partie du code de l'application si un objet disposant d'une méthode "
+":meth:`__getattr__` fait partie de l'expression."
 
 #: ../src/Doc/tutorial/interactive.rst:113
 msgid ""
@@ -4972,10 +5029,18 @@ msgid ""
 "imported modules, such as :mod:`os`, which turn out to be needed in most "
 "sessions with the interpreter. ::"
 msgstr ""
+"Un fichier de démarrage plus complet peut ressembler à cet exemple. Notez que "
+"celui-ci supprime les noms qu'il crée dès qu'ils ne sont plus nécessaires ; "
+"ceci est possible car le fichier de démarrage est exécuté dans le même "
+"espace de noms que les commandes interactives, et supprimer les noms évite "
+"de générer des effets de bord dans l'environnement interactif. Vous pouvez "
+"trouver pratique de conserver certains des modules importés, tels que "
+":mod:`os`, qui s'avère nécessaire dans la plupart des sessions avec "
+"l'interpréteur."
 
 #: ../src/Doc/tutorial/interactive.rst:149
 msgid "Alternatives to the Interactive Interpreter"
-msgstr ""
+msgstr "Alternatives à l'interpréteur interactif"
 
 #: ../src/Doc/tutorial/interactive.rst:151
 msgid ""
@@ -4986,6 +5051,13 @@ msgid ""
 "interpreter's symbol table.  A command to check (or even suggest) matching "
 "parentheses, quotes, etc., would also be useful."
 msgstr ""
+"Cette facilité constitue un énorme pas en avant comparé aux versions "
+"précédentes de l'interpréteur ; toutefois, certains souhaits sont laissés de "
+"côté : ce serait bien si une indentation correcte était proposée sur les "
+"lignes de continuation (l'analyseur sait si une indentation doit suivre). "
+"Le mécanisme de complétion devrait utiliser la table de symboles de "
+"l'interpréteur. Une commande pour vérifier (ou même suggérer) les "
+"correspondances de parenthèses, de guillemets..., serait également utile."
 
 # fe2adb8ab2894fa58e38a0a9e9e22c21
 #: ../src/Doc/tutorial/interactive.rst:158
@@ -4996,6 +5068,12 @@ msgid ""
 "customized and embedded into other applications.  Another similar enhanced "
 "interactive environment is bpython_."
 msgstr ""
+"Une alternative améliorée de l'interpréteur interactif qui a été développée "
+"depuis maintenant quelques temps est IPython_, qui fournit la complétude, "
+"l'exploration d'objets et une gestion avancée de l'historique. Il peut "
+"également être personnalisé en profondeur et embarqué dans d'autres "
+"applications. Un autre environnement interactif amélioré similaire est "
+"bpython_."
 
 # 4e8a30bcc9b34e4e8be51474820e2db6
 #: ../src/Doc/tutorial/interactive.rst:167
@@ -5005,6 +5083,10 @@ msgid ""
 "interpreter.  To customize Python even for non-interactive mode, see :ref:"
 "`tut-customize`."
 msgstr ""
+"Python exécute le contenu d'un fichier identifié par la variable "
+"d'environnement :envvar:`PYTHONSTARTUP` lorsque vous démarrez un interpréteur "
+"interactif. Pour personnaliser Python y compris en mode non interactif, "
+"consultez :ref:`tut-customize`."
 
 #: ../src/Doc/tutorial/interpreter.rst:5
 msgid "Using the Python Interpreter"


### PR DESCRIPTION
Fichiers traduits dans tutorial.po :
- controlflow.rst
- errors.rst
- inputoutput.rst
- interactive.rst

Pas de remarque particulière, mais une petite relecture ne fera certainement pas de mal...

Quelques doutes sur quelques traductions tout de même dans "interactive.rst" :-/
